### PR TITLE
Fix menu link for relative urls

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -15,5 +15,5 @@ Redmine::Plugin.register :redmine_resque do
 
   requires_redmine :version_or_higher => '2.1'
 
-  menu :top_menu, 'Resque', '/resque', :if => Proc.new { User.current.admin? }
+  menu :top_menu, 'Resque', 'resque', :if => Proc.new { User.current.admin? }
 end


### PR DESCRIPTION
When running Redmine in a relative url such as '/redmine' the menu link is generated incorrectly.  When creating a menu link you do not have to add a starting '/' since they are always evaluated from the root_path.  This pull request removes the slash.
